### PR TITLE
Fix for invalid generated css class name

### DIFF
--- a/lib/rails/generators/sass/assets/templates/stylesheet.css.sass
+++ b/lib/rails/generators/sass/assets/templates/stylesheet.css.sass
@@ -2,5 +2,5 @@
 // They will automatically be included in application.css.
 // You can use Sass here: http://sass-lang.com/
 
-body.<%= name.dasherize %>
+body.<%= name.parameterize.dasherize %>
   // Place scoped styles here

--- a/lib/rails/generators/scss/assets/templates/stylesheet.css.scss
+++ b/lib/rails/generators/scss/assets/templates/stylesheet.css.scss
@@ -2,6 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-body.<%= name.dasherize %> {
+body.<%= name.parameterize.dasherize %> {
   // Place scoped styles here
 }

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -14,12 +14,26 @@ class SassRailsTest < Sass::Rails::TestCase
       assert_not_output(/conflict/)
     end
   end
-  test "sass files are generated during scaffold generation sass projects" do
+  test "sass files are generated during scaffold generation of sass projects" do
     within_rails_app "sass_project" do
       runcmd "rails generate scaffold foo"
       assert_file_exists "app/assets/stylesheets/foos.css.sass"
       assert_file_exists "app/assets/stylesheets/scaffolds.css.sass"
       assert_not_output(/conflict/)
+    end
+  end
+  test "scss template has correct dasherized css class for namespaced controllers" do
+    within_rails_app "scss_project" do
+      runcmd "rails generate controller foo/bar"
+      assert_file_exists "app/assets/stylesheets/foo/bar.css.scss"
+      assert_match File.read("app/assets/stylesheets/foo/bar.css.scss"), /\.foo-bar/
+    end
+  end
+  test "sass template has correct dasherized css class for namespaced controllers" do
+    within_rails_app "sass_project" do
+      runcmd "rails generate controller foo/bar"
+      assert_file_exists "app/assets/stylesheets/foo/bar.css.sass"
+      assert_match File.read("app/assets/stylesheets/foo/bar.css.sass"), /\.foo-bar/
     end
   end
   test "templates are registered with sprockets" do


### PR DESCRIPTION
Ensures namespaced sass/scss templates don't generate invalid CSS class names (e.g. foo/bar should generate foo-bar) .
