### PR TITLE
Fix 1.8-specific test failures.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 gemspec
 
 gem "rails", :git => "git://github.com/rails/rails.git", :branch => "3-1-stable"
+gem "sfl", "~> 2.0"
 gem "sprockets"
 
 # To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)

--- a/test/fixtures/sass_project/config/initializers/session_store.rb
+++ b/test/fixtures/sass_project/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-ScssProject::Application.config.session_store :cookie_store, key: '_scss_project_session'
+ScssProject::Application.config.session_store :cookie_store, :key => '_scss_project_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/test/fixtures/sass_project/config/initializers/wrap_parameters.rb
+++ b/test/fixtures/sass_project/config/initializers/wrap_parameters.rb
@@ -4,7 +4,7 @@
 # which will be enabled by default in the upcoming version of Ruby on Rails.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActionController::Base.wrap_parameters format: [:json]
+ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.
 if defined?(ActiveRecord)

--- a/test/fixtures/scss_project/config/initializers/session_store.rb
+++ b/test/fixtures/scss_project/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-ScssProject::Application.config.session_store :cookie_store, key: '_scss_project_session'
+ScssProject::Application.config.session_store :cookie_store, :key => '_scss_project_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/test/fixtures/scss_project/config/initializers/wrap_parameters.rb
+++ b/test/fixtures/scss_project/config/initializers/wrap_parameters.rb
@@ -4,7 +4,7 @@
 # which will be enabled by default in the upcoming version of Ruby on Rails.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActionController::Base.wrap_parameters format: [:json]
+ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.
 if defined?(ActiveRecord)

--- a/test/sass_rails_logger_test.rb
+++ b/test/sass_rails_logger_test.rb
@@ -14,7 +14,7 @@ class SassRailsLoggerTest < Sass::Rails::TestCase
         app_root = runcmd 'rails runner "print Rails.root"'
 
         message = "[#{level}]: sass message"
-        runcmd %{rails runner "Sass::logger.log_level = :#{level}; Sass::logger.log(:#{level}, '#{message}')"}
+        runcmd %{rails runner "Sass::logger.log_level = :#{level}; Sass::logger.log(:#{level}, %Q|#{message}|)"}
 
         log_output = File.open("#{app_root}/log/development.log").read
         assert log_output.include?(message), "the #{level} log message was not found in the log file"

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -26,14 +26,14 @@ class SassRailsTest < Sass::Rails::TestCase
     within_rails_app "scss_project" do
       runcmd "rails generate controller foo/bar"
       assert_file_exists "app/assets/stylesheets/foo/bar.css.scss"
-      assert_match File.read("app/assets/stylesheets/foo/bar.css.scss"), /\.foo-bar/
+      assert_match /\.foo-bar/, File.read("app/assets/stylesheets/foo/bar.css.scss")
     end
   end
   test "sass template has correct dasherized css class for namespaced controllers" do
     within_rails_app "sass_project" do
       runcmd "rails generate controller foo/bar"
       assert_file_exists "app/assets/stylesheets/foo/bar.css.sass"
-      assert_match File.read("app/assets/stylesheets/foo/bar.css.sass"), /\.foo-bar/
+      assert_match /\.foo-bar/, File.read("app/assets/stylesheets/foo/bar.css.sass")
     end
   end
   test "templates are registered with sprockets" do
@@ -42,7 +42,7 @@ class SassRailsTest < Sass::Rails::TestCase
   end
   test "sprockets require works correctly" do
     css_output = sprockets_render("scss_project", "css_application.css")
-    assert_match css_output, /globbed/
+    assert_match /globbed/, css_output
   end
   test "sass imports work correctly" do
     css_output = sprockets_render("scss_project", "application.css.scss")

--- a/test/support/sass_rails_test_case.rb
+++ b/test/support/sass_rails_test_case.rb
@@ -151,7 +151,7 @@ class Sass::Rails::TestCase < ActiveSupport::TestCase
     env["BUNDLE_GEMFILE"] = "#{working_directory}/#{gemfile}" if clean_env
     todo = Proc.new do
       r, w = IO.pipe
-      pid = spawn(env, cmd, :out =>w , :err => w, :chdir => working_directory)
+      pid = Kernel.spawn(env, cmd, :out =>w , :err => w, :chdir => working_directory)
       w.close
       Process.wait
       output = r.read

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require 'rails'
 require "rails/test_help"
 require 'sass/rails'
+require 'sfl'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
This commit fixes makes the tests that failed in MRI 1.8.7 pass (Issue #15).

I still have 2 tests failing in MRI 1.9.2, and now they're failing in the same way in 1.8.7 (Issue #16), but I believe those should be addressed separately.

Thank you!
