### PR TITLE
Helpers use hyphens, not underscores

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,19 +45,20 @@ The [list of supported options](http://sass-lang.com/docs/yardoc/file.SASS_REFER
   cascade ordering for imports that contain styles using this approach.
 
 * **Asset Helpers**. When using the asset pipeline, paths to assets must be rewritten.
-  When referencing assets use the following asset helpers:
+  When referencing assets use the following asset helpers (underscored in Ruby, hyphenated
+  in Sass):
 
   * `asset_path($relative-asset-path, $asset-class)` - Returns a string to the asset.
-    For example: `asset_path("rails.png", image)` becomes `"/assets/rails.png"`
+    For example: `asset-path("rails.png", image)` becomes `"/assets/rails.png"`
   * `asset_url($relative-asset-path, $asset-class)` - Returns url reference to the asset.
     
-    For example: `asset_url("rails.png", image)` becomes `url(/assets/rails.png)`
+    For example: `asset-url("rails.png", image)` becomes `url(/assets/rails.png)`
   * As a convenience, for each of the following asset classes there are
-    corresponding `_path` and `_url` helpers:
+    corresponding `-path` and `-url` helpers:
     image, font, video, audio, javascript, stylesheet.
     
-    For example: `image_url("rails.png")` becomes `url(/assets/rails.png)` and
-    `image_path("rails.png")` becomes `"/assets/rails.png"`.
+    For example: `image-url("rails.png")` becomes `url(/assets/rails.png)` and
+    `image-path("rails.png")` becomes `"/assets/rails.png"`.
   
 
 ## Running Tests


### PR DESCRIPTION
This really messed me up: in Sass, you have to use hyphens not underscores to refer to functions (i.e. 'image-url' not 'image_url'). The README currently uses underscores in its examples, so this changes that.
