### PR TITLE
Handle having asset pipeline disabled

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -39,8 +39,15 @@ module Sass::Rails
         # Display a stack trace in the css output when in development-like environments.
         config.sass.full_exception = app.config.consider_all_requests_local
       end
-      app.assets.context_class.extend(SassContext)
-      app.assets.context_class.sass_config = app.config.sass
+
+      # app.assets might be nil if asset pipeline is not enabled
+      if app.assets
+        app.assets.context_class.extend(SassContext)
+        app.assets.context_class.sass_config = app.config.sass
+      else
+        $stderr.puts 'sass-rails now requires asset pipeline to be enabled. ' <<
+          'Please put config.assets.enabled = true into your application.rb file.'
+      end
     end
 
     initializer :setup_compression do |app|


### PR DESCRIPTION
See [#22](https://github.com/rails/sass-rails/issues/22#issuecomment-1785837).

Rails 3.1 still defaults to `config.assets.enabled = false` for existing apps: https://github.com/rails/rails/blob/d9d78d4165d14184be77/railties/lib/rails/application/configuration.rb#L36.
