### PR TITLE
Fix importer relative paths

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -33,7 +33,7 @@ module Sass::Rails
     def resolve(name, base_pathname = nil)
       name = Pathname.new(name)
       if base_pathname && base_pathname.to_s.size > 0
-        root = Pathname.new(context.root_path)
+        root = context.pathname.dirname
         name = base_pathname.relative_path_from(root).join(name)
       end
       partial_name = name.dirname.join("_#{name.basename}")


### PR DESCRIPTION
Hello,

I stumbled into an issue while using bourbon (specifically [#26](https://github.com/thoughtbot/bourbon/issues/26)) that lead me to discover a flaw with relative path handling in the sass-rails importer.

This pull request solves this relative path issue by making use of the directory of the context rather than the root path of the context for relative asset resolution.

Unfortunately, I have not been able to get the sass-rails tests running (are they broken?) so I have been unable to write a failing test against 3-1-stable and ensure that my modification hasn't broken any previous tests.  I am more than happy to do so if you can give me some pointers as to how to get the tests running! :-)

This modification seems to work happily in my real-world application, but I think it should undergo a little more general case testing before being merged.

Cheers,

Mark.

PS. it might be worth throwing sass-rails at Travis-CI as it's on the verge of being rails core and, as such, should probably be subject to the same continuous integration tests as rails itself. :)
