### PR TITLE
Depend on sass 3.1.11

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sass-rails"
 
-  s.add_runtime_dependency 'sass',       '~> 3.1.11'
+  s.add_runtime_dependency 'sass', :git => 'git://github.com/nex3/sass.git'
   s.add_runtime_dependency 'railties',   '~> 3.1.0'
   s.add_runtime_dependency 'actionpack', '~> 3.1.0'
   s.add_runtime_dependency 'tilt',       '~> 1.3.2'


### PR DESCRIPTION
There are some great improvements in sass 3.1.11, including the allowance for control directives to be nested beneath properties.

Tests pass.

Do I need to update the Changelog or anything else?
