### PR TITLE
Adds `data_uri` helper which seems more in line with the Rails `asset_data_uri` method.

### DIFF
--- a/lib/sass/rails/helpers.rb
+++ b/lib/sass/rails/helpers.rb
@@ -6,6 +6,11 @@ module Sass
         data = context_asset_data_uri(path.value)
         Sass::Script::String.new(%Q{url(#{data})})
       end
+      
+      def data_uri(path)
+        data = context_asset_data_uri(path.value)
+        Sass::Script::String.new(data)
+      end
 
       def asset_path(asset, kind)
         Sass::Script::String.new(public_path(asset.value, kind.value), true)


### PR DESCRIPTION
The existing helper outputs "url(...)" which is kind of weird, and uses "url" which isn't totally obvious.
