### PR TITLE
sfl is not required by Ruby 1.9.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'bundler/setup'
 require 'rails'
 require "rails/test_help"
 require 'sass/rails'
-require 'sfl'
+require 'sfl' if RUBY_VERSION < '1.9'
 require 'mocha'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Make test suite run with Ruby 1.9 without need of sfl gem.
