### PR TITLE
Sfl not needed anymore.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'bundler/setup'
 require 'rails'
 require "rails/test_help"
 require 'sass/rails'
-require 'sfl'
 require 'mocha'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Removed sfl, since according to #113, master does not support Ruby 1.8 anymore.
