### PR TITLE
Version bump for sprockets-rails

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sass',            '>= 3.1.10'
   s.add_runtime_dependency 'railties',        '>= 4.0.0.beta', '< 5.0'
   s.add_runtime_dependency 'tilt',            '~> 1.3'
-  s.add_runtime_dependency 'sprockets-rails', '~> 2.0'
+  s.add_runtime_dependency 'sprockets-rails', '~> 2.0.0.rc0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
So bundle and travs can run tests.

The same change was done for rails core. See commit 18e979e on rails/rails.
