### PR TITLE
Remove unused SassContext module

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -2,10 +2,6 @@ require 'sprockets/railtie'
 
 module Sass::Rails
   class Railtie < ::Rails::Railtie
-    module SassContext
-      attr_accessor :sass_config
-    end
-
     config.sass = ActiveSupport::OrderedOptions.new
 
     # Establish static configuration defaults


### PR DESCRIPTION
It was removed here https://github.com/rails/sass-rails/commit/d357b0194015b05bf54f25ab7be6d6add5a91d1f#L1L66
