### PR TITLE
Added failing test while importing stylesheets with erb handlers

### DIFF
--- a/test/fixtures/scss_project/app/assets/stylesheets/application.css.scss
+++ b/test/fixtures/scss_project/app/assets/stylesheets/application.css.scss
@@ -4,6 +4,7 @@
 @import "subfolder/plain";
 @import "subfolder/second_level";
 @import "partials/without_css_ext";
+@import "erb_handler";
 
 .main {
   color: yellow;

--- a/test/fixtures/scss_project/app/assets/stylesheets/erb_handler.css.erb
+++ b/test/fixtures/scss_project/app/assets/stylesheets/erb_handler.css.erb
@@ -1,0 +1,3 @@
+.erb-handler {
+  margin: <%= 0 %>;
+}

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -81,6 +81,7 @@ class SassRailsTest < Sass::Rails::TestCase
     assert_match /plain-old-css/,            css_output
     assert_match /another-plain-old-css/,    css_output
     assert_match /without-css-ext/,          css_output
+    assert_match /erb-handler/,              css_output
   end
 
   test 'sass asset paths work' do


### PR DESCRIPTION
Exhibits Sass::SyntaxError "File to import not found or unreadable" while
trying to import a stylesheet of the form file.{css,scss}.erb

[#139]
