### PR TITLE
Remove postprocessors from asset evaluation

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -81,9 +81,10 @@ module Sprockets
       end
 
       def evaluate(filename)
-        processors = context.environment.attributes_for(filename).processors.reject { |processor|
-          processor.in? [Sprockets::ScssTemplate, Sprockets::SassTemplate]
-        }
+        attributes = context.environment.attributes_for(filename)
+        processors = context.environment.preprocessors(attributes.content_type) +
+          attributes.engines.reverse - [Sprockets::ScssTemplate, Sprockets::SassTemplate]
+
         context.evaluate(filename, processors: processors)
       end
   end

--- a/test/fixtures/scss_project/config/initializers/postprocessor.rb
+++ b/test/fixtures/scss_project/config/initializers/postprocessor.rb
@@ -1,0 +1,3 @@
+Rails.application.assets.register_postprocessor 'text/css', :postprocessor do |context, css|
+  css.gsub /@import/, 'fail engine'
+end


### PR DESCRIPTION
This pull request closes #163. 

Further explanation of the problem:
postprocessors expect data already parsed by preprocessors and engines, but sass-rails sends raw data not yet parsed by scss or sass engines.
