### PR TITLE
ensure parents of globbed files are added to dependencies

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -47,9 +47,9 @@ module Sprockets
       contents = ""
       each_globbed_file(glob, base_pathname.dirname, options) do |filename|
         if File.directory?(filename)
-          context.depend_on(filename)
+          depend_on(filename)
         elsif context.asset_requirable?(filename)
-          context.depend_on(filename)
+          depend_on(filename)
           contents << "@import #{Pathname.new(filename).relative_path_from(base_pathname.dirname).to_s.inspect};\n"
         end
       end
@@ -62,6 +62,19 @@ module Sprockets
     end
 
     private
+
+      def depend_on(filename)
+        context.depend_on(filename)
+        context.depend_on(globbed_file_parent(filename))
+      end
+
+      def globbed_file_parent(filename)
+        if File.directory?(filename)
+          File.expand_path('..', filename)
+        else
+          File.dirname(filename)
+        end
+      end
 
       def engine_from_path(name, dir, options)
         full_filename, syntax = Sass::Util.destructure(find_real_file(dir, name, options))

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -89,6 +89,23 @@ class SassRailsTest < Sass::Rails::TestCase
     assert_match /default-old-css/,          css_output
   end
 
+  test 'globbed imports work when new file is added' do
+    project = 'scss_project'
+    filename = 'application.css.scss'
+
+    within_rails_app(project) do |tmpdir|
+      asset_output(filename)
+
+      new_file = File.join(tmpdir, 'app', 'assets', 'stylesheets', 'globbed', 'new.scss')
+      File.open(new_file, 'w') do |file|
+        file.puts '.new-file-test { color: #000; }'
+      end
+
+      css_output = asset_output(filename)
+      assert_match /new-file-test/, css_output
+    end
+  end
+
   test 'sass asset paths work' do
     css_output = sprockets_render('scss_project', 'application.css.scss')
     assert_match %r{asset-path:\s*"/assets/rails.png"},                           css_output, 'asset-path:\s*"/assets/rails.png"'

--- a/test/support/sass_rails_test_case.rb
+++ b/test/support/sass_rails_test_case.rb
@@ -37,8 +37,12 @@ class Sass::Rails::TestCase < ActiveSupport::TestCase
 
   def sprockets_render(project, filename)
     within_rails_app(project) do
-      runcmd "ruby script/rails runner 'puts Rails.application.assets[#{filename.inspect}]'"
+      asset_output(filename)
     end
+  end
+
+  def asset_output(filename)
+    runcmd "ruby script/rails runner 'puts Rails.application.assets[#{filename.inspect}]'"
   end
 
   def assert_file_exists(filename)


### PR DESCRIPTION
This should fix #107.  The problem appears to be that the "parent directory" of the globbed file is not being added to the dependencies.

For example if I have the following:

``` css
@import "*.scss";
```

Each of the files found by the glob was being added to the dependencies, but the `stylesheets` directory was not.

Perhaps my implementation of `globbed_file_parent` is overly naive.
