### PR TITLE
Remove sass `cache_location` config.

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -46,9 +46,6 @@ module Sass::Rails
       # Override stylesheet engine to the preferred syntax
       config.app_generators.stylesheet_engine syntax
 
-      # Set the sass cache location
-      config.sass.cache_location   = File.join(Rails.root, "tmp/cache/sass")
-
       # Establish configuration defaults that are evironmental in nature
       if config.sass.full_exception.nil?
         # Display a stack trace in the css output when in development-like environments.


### PR DESCRIPTION
Since 093ad1d0 the `cache_store` option is used, `cache_location` is
ignored.

http://sass-lang.com/documentation/file.SASS_REFERENCE.html#cache_location-option
