### PR TITLE
Allow Sass 3.3

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sass-rails"
 
-  s.add_dependency 'sass',            '~> 3.2'
+  s.add_dependency 'sass',            '>= 3.2', '<= 3.4'
   s.add_dependency 'railties',        '>= 4.0.0', '< 5.0'
   s.add_dependency 'sprockets-rails', '~> 2.0'
   s.add_dependency 'sprockets',       '~> 2.12'

--- a/sass-rails.gemspec.erb
+++ b/sass-rails.gemspec.erb
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sass-rails"
 
-  s.add_dependency 'sass',            '~> 3.2'
+  s.add_dependency 'sass',            '>= 3.2', '<= 3.4'
   s.add_dependency 'railties',        '>= 4.0.0', '< 5.0'
   s.add_dependency 'sprockets-rails', '~> 2.0'
   s.add_dependency 'sprockets',       '~> 2.12'


### PR DESCRIPTION
Previous dependency declaration limited Sass to version 3.2.
