### PR TITLE
Bump version to 4.0.3

### DIFF
--- a/lib/sass/rails/version.rb
+++ b/lib/sass/rails/version.rb
@@ -1,5 +1,5 @@
 module Sass
   module Rails
-    VERSION = "4.0.1"
+    VERSION = "4.0.3"
   end
 end


### PR DESCRIPTION
BTW, the current version 4.0.3 has a problem.
1. `mkdir new_rails_app && cd new_rails_app`
2. `bundle init` and enable `gem "rails"` on Gemfile
3. `bundle install --path=vendor/bundle`
4. `bundle exec rails new .`
5. the following error occurred when running `bundle install`

```
Resolving dependencies...
Bundler could not find compatible versions for gem "sprockets":
  In snapshot (Gemfile.lock):
    sprockets (2.12.1)

  In Gemfile:
    sass-rails (~> 4.0.3) ruby depends on
      sprockets (<= 2.11.0, ~> 2.8) ruby

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

So I think it would be helpful if you bump version sass-rails to 4.0.4 and also modify rails Gemfile generator.
