### PR TITLE
Add a default mime extension for .sass files

### DIFF
--- a/lib/sass/rails/template.rb
+++ b/lib/sass/rails/template.rb
@@ -3,6 +3,9 @@ require "sprockets/sass_template"
 module Sass
   module Rails
     class SassTemplate < Sprockets::SassTemplate
+      def self.default_mime_type
+        'text/css'
+      end
 
       def evaluate(context, locals, &block)
         cache_store = Sprockets::SassCacheStore.new(context.environment)
@@ -30,10 +33,6 @@ module Sass
     end
 
     class ScssTemplate < SassTemplate
-      def self.default_mime_type
-        'text/css'
-      end
-
       def syntax
         :scss
       end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/16826

Introduced in https://github.com/rails/sass-rails/commit/a62bdf85e56a678aa5fded3d4ed0d10bbc0b7a7b 
Breaks Sprockets because `default_mime_type` is `nil` here: https://github.com/sstephenson/sprockets/blob/b6ce4bf5a8428ae806cad01403c3f94f1ba5b01e/lib/sprockets/asset_attributes.rb#L122

Using `Sprockets::SassTemplate.default_mime_type` at https://github.com/sstephenson/sprockets/blob/b6ce4bf5a8428ae806cad01403c3f94f1ba5b01e/lib/sprockets/sass_template.rb previously worked when monkey patching `Sprockets::SassTemplate` class, but it is `nil` on inherited `SassTemplate < Sprockets::SassTemplate`
