### PR TITLE
Allow Importer to be serialized

### DIFF
--- a/lib/sass/rails/template.rb
+++ b/lib/sass/rails/template.rb
@@ -33,8 +33,8 @@ module Sass
           :line => line,
           :syntax => syntax,
           :cache_store => cache_store,
-          :importer => importer_class.new(context, context.pathname.to_s),
-          :load_paths => context.environment.paths.map { |path| importer_class.new(context, path.to_s) },
+          :importer => importer_class.new(context.pathname.to_s),
+          :load_paths => context.environment.paths.map { |path| importer_class.new(path.to_s) },
           :sprockets => {
             :context => context,
             :environment => context.environment


### PR DESCRIPTION
This fixes the infamous `can't dump anonymous class` errors while attempting to save sass cache files (see #242).

This is not an issue for pre v5 versions as they do not support sass > 3.2

The problem comes from the sprockets context being an attribute of the importer class and thus making it impossible to serialize it (as far as I understand this).

Inspired by the `sprockets-sass` gem [Importer class](https://github.com/petebrowne/sprockets-sass/blob/master/lib/sprockets/sass/importer.rb).
