### PR TITLE
Update sass-rails.gemspec

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = %q{MIT}
 
   s.add_dependency 'railties',        '>= 4.0.0', '< 5.0'
-  s.add_dependency 'sass',            '~> 3.1'
+  s.add_dependency 'sass',            '~> 3.4.9'
   s.add_dependency 'sprockets-rails', '>= 2.0', '< 4.0'
   s.add_dependency 'sprockets',       '>= 2.8', '< 4.0'
   s.add_dependency 'tilt',            '~> 1.1'


### PR DESCRIPTION
Current gem release fails to deploy. According to http://foundation.zurb.com/forum/posts/21411-error-on-update-55 this is due to a sass update. This conflicts with sass-rails, and the gemspec needs to be accurate so that bundler can tells us as developers about these conflicts.
