### PR TITLE
Add a precision configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Add a `precision` configuration option.
+
 ## 5.0.1
 
 * Fixed @import glob related caching bug

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ can be found on the Sass Website with the following caveats:
 - `:syntax` - This is determined by the file's extensions.
 - `:filename` - This is determined by the file's name.
 - `:line` - This is provided by the template handler.
+- `:precision` - This option allows you to define the number of digits of precision.
 
 ### Example
 

--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -18,6 +18,8 @@ module Sass::Rails
     config.sass.load_paths       = []
     # Send Sass logs to Rails.logger
     config.sass.logger           = Sass::Rails::Logger.new
+    # Define the digits of precision for decimal numbers
+    config.sass.precision        = Sass::Script::Number.precision
 
     # Set the default stylesheet engine
     # It can be overridden by passing:
@@ -63,6 +65,9 @@ module Sass::Rails
       end
 
       Sass.logger = app.config.sass.logger
+
+      # Set Sass' digits of precision for decimal numbers
+      Sass::Script::Number.precision = app.config.sass.precision
     end
 
     initializer :setup_compression, group: :all do |app|

--- a/test/fixtures/sass_project/config/application.rb
+++ b/test/fixtures/sass_project/config/application.rb
@@ -48,5 +48,8 @@ module ScssProject
 
     # Prefer sass for generated assets.
     config.sass.preferred_syntax = :sass
+
+    # Define a custom precision for decimal numbers
+    config.sass.precision = 4
   end
 end

--- a/test/fixtures/scss_project/app/assets/stylesheets/decimals.css.scss
+++ b/test/fixtures/scss_project/app/assets/stylesheets/decimals.css.scss
@@ -1,0 +1,3 @@
+.container {
+  width: (1px/3);
+}

--- a/test/fixtures/scss_project/config/application.rb
+++ b/test/fixtures/scss_project/config/application.rb
@@ -45,5 +45,8 @@ module ScssProject
 
     # Enable the asset pipeline
     config.assets.enabled = true
+
+    # Define a custom precision for decimal numbers
+    config.sass.precision = 3
   end
 end

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -86,6 +86,29 @@ class SassRailsTest < Sass::Rails::TestCase
     end
   end
 
+  test 'precision on decimal numbers is settable' do
+    within_rails_app 'sass_project' do
+      runner 'development' do
+        "puts Rails.application.config.sass.precision"
+      end
+
+      assert_equal '4', $last_output.chomp
+    end
+
+    within_rails_app 'scss_project' do
+      runner 'development' do
+        "puts Rails.application.config.sass.precision"
+      end
+
+      assert_equal '3', $last_output.chomp
+    end
+  end
+
+  test 'decimal numbers are honouring the configuration' do
+    css_output = sprockets_render('scss_project', 'decimals.css.scss')
+    assert_match %r{0.333px}, css_output
+  end
+
   test 'sprockets require works correctly' do
     within_rails_app('scss_project') do |app_root|
       css_output = asset_output('css_application.css')


### PR DESCRIPTION
Hello,

This pull request adds a `precision` configuration option that allows the user to define the number of digits of precision when dealing with decimal numbers.

Fixes #143.

Have a nice day.