### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ rvm:
  - 1.9.3
  - 2.0.0
  - 2.1.1
+ - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: rbx-2
 
 gemfile:
   - test/gemfiles/Gemfile-rails-4-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ rvm:
  - 2.1.1
  - rbx-2
 
-matrix:
-  allow_failures:
-    - rvm: rbx-2
-
 gemfile:
   - test/gemfiles/Gemfile-rails-4-0
   - test/gemfiles/Gemfile-rails-4-1
@@ -30,6 +26,8 @@ sudo: false
 script: bundle exec rake test
 
 matrix:
+  allow_failures:
+    - rvm: rbx-2
   exclude:
     - gemfile: Gemfile
       rvm: 1.9.3


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I am trying to add this to ensure this Gem works in Rubinius and to complete this dashboard: http://bjfish.github.io/rubinius-gem-build-status/page2/.