### PR TITLE
Only access environment directly in configure block

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -52,11 +52,11 @@ module Sass::Rails
         config.sass.full_exception = app.config.consider_all_requests_local
       end
 
-      if app.assets
-        app.assets.register_engine '.sass', Sass::Rails::SassTemplate
-        app.assets.register_engine '.scss', Sass::Rails::ScssTemplate
+      config.assets.configure do |env|
+        env.register_engine '.sass', Sass::Rails::SassTemplate
+        env.register_engine '.scss', Sass::Rails::ScssTemplate
 
-        app.assets.context_class.class_eval do
+        env.context_class.class_eval do
           class_attribute :sass_config
           self.sass_config = app.config.sass
         end


### PR DESCRIPTION
Should fix some issues mentioned by @rafaelfranca and @lucasmazza over on https://github.com/rails/sprockets/issues/10#issuecomment-84731912.

This should work even on really old sprockets-rails versions. Might want to get this backported to the `4-0-stable` branch here.

Kinda wanted to add some test matrix coverage here to try to show this fails and fixes the issue on newer sprockets-rails versions.