### PR TITLE
Add missing sass requires

### DIFF
--- a/lib/sass/rails/helpers.rb
+++ b/lib/sass/rails/helpers.rb
@@ -1,3 +1,4 @@
+require 'sass'
 require 'sprockets/sass_functions'
 
 module Sprockets

--- a/lib/sass/rails/logger.rb
+++ b/lib/sass/rails/logger.rb
@@ -1,3 +1,4 @@
+require 'sass'
 require 'sass/logger'
 
 module Sass

--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -1,3 +1,4 @@
+require 'sass'
 require 'active_support/core_ext/class/attribute'
 require 'sprockets/railtie'
 


### PR DESCRIPTION
Looks like some of this files reference `::Sass` but don't ever require it. The load order of these files is kinda undefined, so its probably best to just for each one to be explicit and require sass if they intend to use `::Sass`

cc @rafaelfranca @lucasmazza 