### PR TITLE
Allow no compression for all environments

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -68,7 +68,9 @@ module Sass::Rails
 
     initializer :setup_compression, group: :all do |app|
       unless Rails.env.development?
-        app.config.assets.css_compressor ||= :sass
+        # config.assets.css_compressor may be set to nil in non-dev environments.
+        # otherwise, the default is sass compression.
+        app.config.assets.css_compressor = :sass unless app.config.assets.has_key?(:css_compressor)
       else
         # Use expanded output instead of the sass default of :nested unless specified
         app.config.sass.style ||= :expanded

--- a/test/fixtures/alternate_config_project/config/environments/test.rb
+++ b/test/fixtures/alternate_config_project/config/environments/test.rb
@@ -39,4 +39,7 @@ AlternateConfigProject::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Decide not to use sass compression
+  config.assets.css_compressor = nil
 end

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -76,6 +76,16 @@ class SassRailsTest < Sass::Rails::TestCase
     end
   end
 
+  test 'sass allows compressor override in test mode' do
+    within_rails_app 'alternate_config_project' do
+      runner 'test' do
+        "puts Rails.application.config.assets.css_compressor.nil?"
+      end
+
+      assert_equal 'true', $last_output.chomp
+    end
+  end
+
   test 'sass defines compressor by default in production mode' do
     within_rails_app 'scss_project' do
       runner 'production' do


### PR DESCRIPTION
Change https://github.com/rails/sass-rails/commit/339529f9f6433047df6358c0439e6641cb74f045 made it so that one can no longer turn off compression in any environment except development.  This is both a bit confusing (e.g. you set it to nil and expect it to work, but it doesn't!) and difficult if you really want to turn compression off.  This change allows the statement `config.assets.css_compressor = nil` to function in all environments.