### PR TITLE
[ci skip] Correct docs for asset helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ in Sass):
 #### `asset-path($relative-asset-path)`
 Returns a string to the asset.
 
-* `"/assets/rails.png"` becomes `asset-path("rails.png")`
+* `asset-path("rails.png")` returns `"/assets/rails.png"`
 
 #### `asset-url($relative-asset-path)`
 Returns a url reference to the asset.
 
-* `url(/assets/rails.png)` becomes `asset-url("rails.png")`
+* `asset-url("rails.png")` returns `url(/assets/rails.png)`
 
 As a convenience, for each of the following asset classes there are
 corresponding `-path` and `-url` helpers:
 image, font, video, audio, javascript, stylesheet.
 
-* `"/assets/rails.png"` becomes `image-path("rails.png")`
-* `url(/assets/rails.png)` becomes `image-url("rails.png")`
+* `image-path("rails.png")` returns `"/assets/rails.png"`
+* `image-url("rails.png")` returns `url(/assets/rails.png)`
 
 #### `asset-data-url($relative-asset-path)`
 Returns a url reference to the Base64-encoded asset at the specified path.
 
-* `url(data:image/png;base64,iVBORw0K...)` becomes `asset-data-url("rails.png")`
+* `asset-data-url("rails.png")` returns `url(data:image/png;base64,iVBORw0K...)`
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ in Sass):
 #### `asset-path($relative-asset-path)`
 Returns a string to the asset.
 
-* `asset-path("rails.png")` becomes `"/assets/rails.png"`
+* `"/assets/rails.png"` becomes `asset-path("rails.png")`
 
 #### `asset-url($relative-asset-path)`
 Returns a url reference to the asset.
 
-* `asset-url("rails.png")` becomes `url(/assets/rails.png)`
+* `url(/assets/rails.png)` becomes `asset-url("rails.png")`
 
 As a convenience, for each of the following asset classes there are
 corresponding `-path` and `-url` helpers:
 image, font, video, audio, javascript, stylesheet.
 
-* `image-path("rails.png")` becomes `"/assets/rails.png"`
-* `image-url("rails.png")` becomes `url(/assets/rails.png)`
+* `"/assets/rails.png"` becomes `image-path("rails.png")`
+* `url(/assets/rails.png)` becomes `image-url("rails.png")`
 
 #### `asset-data-url($relative-asset-path)`
 Returns a url reference to the Base64-encoded asset at the specified path.
 
-* `asset-data-url("rails.png")` becomes `url(data:image/png;base64,iVBORw0K...)`
+* `url(data:image/png;base64,iVBORw0K...)` becomes `asset-data-url("rails.png")`
 
 ## Running Tests
 


### PR DESCRIPTION
The instructions for asset helpers were reversed, so the docs told you to replace the new expression ('image-url') with the old one ('url') instead of the other way around.