### PR TITLE
Find erb when importing glob

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -145,8 +145,8 @@ module Sass
           end
       end
 
-      include Deprecated
       include ERB
+      include Deprecated
       include Globbing
 
       # Allow .css files to be @import'd

--- a/test/fixtures/scss_project/app/assets/stylesheets/globbed/nested/nested_glob_erb.scss.erb
+++ b/test/fixtures/scss_project/app/assets/stylesheets/globbed/nested/nested_glob_erb.scss.erb
@@ -1,0 +1,3 @@
+.nested-glob-erb {
+  color: <%= 'blue' %>;
+}

--- a/test/fixtures/scss_project/app/assets/stylesheets/globbed/nested/nested_glob_erb_css_scss.css.scss.erb
+++ b/test/fixtures/scss_project/app/assets/stylesheets/globbed/nested/nested_glob_erb_css_scss.css.scss.erb
@@ -1,0 +1,3 @@
+.nested-glob-erb-css-scss {
+  color: <%= 'blue' %>;
+}

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -126,6 +126,7 @@ class SassRailsTest < Sass::Rails::TestCase
     assert_match /globbed/,                  css_output
     assert_match /nested-glob/,              css_output
     assert_match /nested-glob-erb/,          css_output
+    assert_match /nested-glob-erb-css-scss/, css_output
     assert_match /plain-old-css/,            css_output
     assert_match /another-plain-old-css/,    css_output
     assert_match /without-css-ext/,          css_output

--- a/test/sass_rails_test.rb
+++ b/test/sass_rails_test.rb
@@ -125,6 +125,7 @@ class SassRailsTest < Sass::Rails::TestCase
     assert_match /not-a-partial/,            css_output
     assert_match /globbed/,                  css_output
     assert_match /nested-glob/,              css_output
+    assert_match /nested-glob-erb/,          css_output
     assert_match /plain-old-css/,            css_output
     assert_match /another-plain-old-css/,    css_output
     assert_match /without-css-ext/,          css_output


### PR DESCRIPTION
Including an erb in a globbed include would result in a `File to import not found or unreadable` error. This was happening because the `ERB` and `Deprecated` modules of the `importer` were both adding items with the same value to the `extensions` hash.  The sass gem's `Filesystem` importer does an `invert` on the `extensions` hash to apply the file's extension and was not resolving these correctly.  Changing the order of the imports resolves the issue.  This looks like the same problem reported in issue #185.

    