### PR TITLE
Support Rails 5.0

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Sass adapter for the Rails asset pipeline.}
   s.license     = %q{MIT}
 
-  s.add_dependency 'railties',        '>= 4.0.0', '< 5.0'
+  s.add_dependency 'railties',        '>= 4.0.0', '< 5.1'
   s.add_dependency 'sass',            '~> 3.4'
   s.add_dependency 'sprockets-rails', '< 4.0'
   s.add_dependency 'sprockets',       '>= 4.0'

--- a/test/fixtures/alternate_config_project/config/environments/production.rb
+++ b/test/fixtures/alternate_config_project/config/environments/production.rb
@@ -11,7 +11,9 @@ AlternateConfigProject::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = false
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = false
   else
     config.serve_static_assets = false

--- a/test/fixtures/alternate_config_project/config/environments/test.rb
+++ b/test/fixtures/alternate_config_project/config/environments/test.rb
@@ -8,12 +8,19 @@ AlternateConfigProject::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = true
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = true
   else
     config.serve_static_assets = true
   end
-  config.static_cache_control = "public, max-age=3600"
+
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.static_cache_control = "public, max-age=3600"
+  end
 
   config.eager_load = false
 

--- a/test/fixtures/engine_project/test/dummy/config/environments/production.rb
+++ b/test/fixtures/engine_project/test/dummy/config/environments/production.rb
@@ -20,7 +20,9 @@ Dummy::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = false
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = false
   else
     config.serve_static_assets = false

--- a/test/fixtures/engine_project/test/dummy/config/environments/test.rb
+++ b/test/fixtures/engine_project/test/dummy/config/environments/test.rb
@@ -13,12 +13,19 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = true
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = true
   else
     config.serve_static_assets = true
   end
-  config.static_cache_control = "public, max-age=3600"
+
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.static_cache_control = "public, max-age=3600"
+  end
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/fixtures/sass_project/config/environments/production.rb
+++ b/test/fixtures/sass_project/config/environments/production.rb
@@ -12,7 +12,9 @@ ScssProject::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = false
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = false
   else
     config.serve_static_assets = false

--- a/test/fixtures/sass_project/config/environments/test.rb
+++ b/test/fixtures/sass_project/config/environments/test.rb
@@ -11,12 +11,19 @@ ScssProject::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = true
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = true
   else
     config.serve_static_assets = true
   end
-  config.static_cache_control = "public, max-age=3600"
+
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.static_cache_control = "public, max-age=3600"
+  end
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/test/fixtures/scss_project/config/environments/production.rb
+++ b/test/fixtures/scss_project/config/environments/production.rb
@@ -11,7 +11,9 @@ ScssProject::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = false
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = false
   else
     config.serve_static_assets = false

--- a/test/fixtures/scss_project/config/environments/test.rb
+++ b/test/fixtures/scss_project/config/environments/test.rb
@@ -10,12 +10,19 @@ ScssProject::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  if config.respond_to?(:serve_static_files)
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.enabled = true
+  elsif config.respond_to?(:serve_static_files)
     config.serve_static_files = true
   else
     config.serve_static_assets = true
   end
-  config.static_cache_control = "public, max-age=3600"
+
+  if config.respond_to?(:public_file_server)
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.static_cache_control = "public, max-age=3600"
+  end
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true


### PR DESCRIPTION
I want to test rails 5.0.0.beta1 in my rails app. But sass-rails's dependency blocks bundle install.
I confirmed we could pass all tests with rails 5.0.0.beta1. This PR includes fixes to pass them, using `config.public_file_server` instead of deprecated APIs.