### PR TITLE
Copy links from imported `.css.erb` stylesheets.

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -99,6 +99,7 @@ module Sass
               processors = [Sprockets::ERBProcessor, Sprockets::FileReader]
 
               result = Sprockets::ProcessorUtils.call_processors(processors, input)
+              result[:links].each { |link| context.link_asset(link) }
 
               Sass::Engine.new(result[:data], engine.options.merge(:syntax => syntax))
             else


### PR DESCRIPTION
This ensures that the assets linked by any imported `.css.erb` file inside a Sass file get collected by their parent stylesheet.

Related to torba-rb/torba-rails#1

/cc @rafaelfranca 
