### PR TITLE
Support Rails 5.1 development

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Sass adapter for the Rails asset pipeline.}
   s.license     = %q{MIT}
 
-  s.add_dependency 'railties',        '>= 4.0.0', '< 5.1'
+  s.add_dependency 'railties',        '>= 4.0.0', '< 5.2'
   s.add_dependency 'sass',            '~> 3.4'
   s.add_dependency 'sprockets-rails', '< 4.0'
   s.add_dependency 'sprockets',       '~> 4.x'


### PR DESCRIPTION
Currently if you try to run a Rails app using a checkout of rails/master
bundler will be unable to resolve a version of railties that will work for
all dependencies. This change to the gemspec should fix that.