### PR TITLE
Add Sass version to SassTemplate cache_key

### DIFF
--- a/lib/sass/rails/template.rb
+++ b/lib/sass/rails/template.rb
@@ -15,6 +15,10 @@ module Sass
         true
       end
 
+      def self.cache_key
+        ::Sass::VERSION
+      end
+
       def initialize_engine
       end
 


### PR DESCRIPTION
Fixes #373 for the 5.x branch. (I'm not sure if this issue is already fixed on the 6.x branch or if it will need a separate fix there.)
