### PR TITLE
try app_middleware instead of middleware

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -32,7 +32,7 @@ module Sass::Rails
 
     # Remove the sass middleware if it gets inadvertently enabled by applications.
     config.after_initialize do |app|
-      app.config.middleware.delete(Sass::Plugin::Rack) if defined?(Sass::Plugin::Rack)
+      app.config.app_middleware.delete(Sass::Plugin::Rack) if defined?(Sass::Plugin::Rack)
     end
 
     initializer :setup_sass, group: :all do |app|


### PR DESCRIPTION
Fixes #385, #136 (`cannot modify frozen Array` issues).

I don't know if this is the "proper" fix for these issues, but it's enough of a workaround for my particular use-case that I thought I'd share to get the ball rolling.

This change doesn't seem to fail any tests, but my guess is that this is due to a lack of test coverage on this particular use case rather than unchanged behavior, so perhaps some followup is still needed.
