### PR TITLE
Prevent beta versions of gems as a dependency

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |s|
   s.description = %q{Sass adapter for the Rails asset pipeline.}
   s.license     = %q{MIT}
 
-  s.add_dependency 'railties',        '>= 4.0.0', '< 6'
+  s.add_dependency 'railties',        '>= 4.0.0', '< 6.x'
   s.add_dependency 'sass',            '~> 3.1'
-  s.add_dependency 'sprockets-rails', '>= 2.0', '< 4.0'
-  s.add_dependency 'sprockets',       '>= 2.8', '< 4.0'
-  s.add_dependency 'tilt',            '>= 1.1', '< 3'
+  s.add_dependency 'sprockets-rails', '>= 2.0', '< 4.x'
+  s.add_dependency 'sprockets',       '>= 2.8', '< 4.x'
+  s.add_dependency 'tilt',            '>= 1.1', '< 3.x'
 
   s.add_development_dependency 'sqlite3'
 


### PR DESCRIPTION
Before, the version dependency for example on sprockets was like this:

    s.add_dependency 'sprockets',       '>= 2.8', '< 4.0'

But this allowed to install beta versions of sprockets like current
`4.0.0.beta3` (because `4.0.0.beta3 < 4.0`). Which is not compatible with
sass-rails.

By using `< 4.x`, it successfully prevents to install any version 4
of sprockets, including beta versions.

Other gem dependencies changed accordingly.