### PR TITLE
Fix ruby warning

### DIFF
--- a/lib/sass/rails/helpers.rb
+++ b/lib/sass/rails/helpers.rb
@@ -3,6 +3,7 @@ require 'sprockets/sass_functions'
 
 module Sprockets
   module SassFunctions
+    remove_method :asset_data_url if method_defined?(:asset_data_url)
     def asset_data_url(path)
       Sass::Script::String.new("url(" + sprockets_context.asset_data_uri(path.value) + ")")
     end


### PR DESCRIPTION
This fixes following warning:

```
gems/sass-rails-5.0.6/lib/sass/rails/helpers.rb:6: warning: method redefined; discarding old asset_data_url
gems/sprockets-3.7.1/lib/sprockets/sass_processor.rb:253: warning: previous definition of asset_data_url was here
```