### PR TITLE
include ERB before Deprecated

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -134,8 +134,8 @@ module Sass
           end
       end
 
-      include Deprecated
       include ERB
+      include Deprecated
       include Globbing
 
       # Allow .css files to be @import'd


### PR DESCRIPTION
If you `include Deprecated` before `include ERB`, you're unable to import `[css/scss/sass].erb` files through globbing. Importing `[css/scss/sass].erb` files directly seems to work fine:
 
![untitled](https://user-images.githubusercontent.com/1104431/28711090-4774744a-737e-11e7-9de1-a29cda6c9903.png)

![untitled](https://user-images.githubusercontent.com/1104431/28711207-b763906a-737e-11e7-934d-7d23ca69c0b1.png)


