### PR TITLE
Update for frozen-string-literal friendliness.

### DIFF
--- a/lib/sass/rails/importer.rb
+++ b/lib/sass/rails/importer.rb
@@ -28,7 +28,7 @@ module Sass
 
         private
           def glob_imports(base, glob, options)
-            contents = ""
+            contents = "".dup
             context = options[:sprockets][:context]
             each_globbed_file(base, glob, context) do |filename|
               next if filename == options[:filename]


### PR DESCRIPTION
One minor change that keeps all currently-passing tests when frozen string literals are in play in MRI 2.4+.

I've done this testing by adding the pragma comment to all Ruby files in lib and test locally, but have not included those changes in this PR. I'm happy to add them in if you'd like, I just don't want to presume whether that's preferred or not.