### PR TITLE
update sass gem

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = %q{MIT}
 
   s.add_dependency 'railties',        '>= 4.0.0', '< 6'
-  s.add_dependency 'sass',            '~> 3.4'
+  s.add_dependency 'sass',            '~> 3.5.3'
   s.add_dependency 'sprockets-rails', '< 4.0'
   s.add_dependency 'sprockets',       '~> 4.x'
 


### PR DESCRIPTION
I can't export the SCSS file in scss/bootstrap.scss, it says:

```
Error: Invalid CSS after "...lor}: #{$value}": expected "{", was ";"
on line 4 of C:/bootstrap-4.0.0-beta.2/scss/_root.scss
from line 11 of C:\bootstrap-4.0.0-beta.2\scss\bootstrap.scss
Use --trace for backtrace.
[Finished in 1.0s]
```

This error is introduced by the sass gem. this is resolved in v3.5.2+.