### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |s|
   s.description = %q{Sass adapter for the Rails asset pipeline.}
   s.license     = %q{MIT}
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/sass-rails/issues",
+    "changelog_uri"     => "https://github.com/rails/sass-rails/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://www.rubydoc.info/gems/sass-rails/#{s.version}",
+    "source_code_uri"   => "https://github.com/rails/sass-rails/tree/v#{s.version}"
+  }
+
   s.add_dependency 'sassc-rails', '~> 2.1', '>= 2.1.1'
 
   s.files         = Dir["MIT-LICENSE", "README.md", "lib/**/*"]


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/sass-rails and be available via the rubygems API after the next release.