### PR TITLE
temporarily update dependency to our own fork

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/rails/sass-rails/tree/v#{s.version}"
   }
 
-  s.add_dependency 'sassc-rails', '~> 2.1', '>= 2.1.1'
+  s.add_dependency 'sassc-rails', github: 'code-dot-org/sassc-rails', ref: 'frozen-array-fix'
 
   s.files         = Dir["MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
 so we can start benefiting from our fix right away, while we work toward getting it accepted upstream